### PR TITLE
Rename uses to tx

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ npm install transform-props-with --save
 ### Usage
 
 ```js
-import transformPropsWith from 'transform-props-with'
+import tx from 'transform-props-with'
 
 import BaseComponent from './base-component'
 
@@ -31,7 +31,7 @@ const doubleSize = (oldProps) => {
   };
 };
 
-const DecoratedComponent = transformPropsWith(doubleSize)(BaseComponent)
+const DecoratedComponent = tx(doubleSize)(BaseComponent)
 
 ReactDOM.render(<DecoratedComponent size={ 100 } />, node);
 // Would render <BaseComponent size={ 200 } />
@@ -63,13 +63,13 @@ The following two examples are then equivalent.
 
 ```js
 const DecoratedComponent =
-  transformPropsWith([doubleSize, addFive])(BaseComponent)
+  tx([doubleSize, addFive])(BaseComponent)
 ```
 
 ```js
 const DecoratedComponent =
-  transformPropsWith(doubleSize)(
-    transformPropsWith(addFive)(BaseComponent)
+  tx(doubleSize)(
+    tx(addFive)(BaseComponent)
   )
 ```
 
@@ -86,7 +86,7 @@ If you like [decorators](https://github.com/wycats/javascript-decorators),
 you can use to apply transformations.
 
 ```js
-@transformPropsWith(doubleSize)
+@tx(doubleSize)
 class DecoratedComponent extends BaseComponent {}
 ```
 

--- a/examples/bem.js
+++ b/examples/bem.js
@@ -2,7 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import cx from 'classnames'
 
-import transformPropsWith from 'transform-props-with'
+import tx from 'transform-props-with'
 
 const addElementStyles = (oldProps) => {
   const { modifier, name, ...props } = oldProps
@@ -18,11 +18,11 @@ const addElementStyles = (oldProps) => {
 const addBodyElementStyles = (props) => Object.assign({}, props, { name: 'body' })
 const addTitleElementStyles = (props) => Object.assign({}, props, { name: 'title' })
 
-const HeaderBody = transformPropsWith([
+const HeaderBody = tx([
   addBodyElementStyles,
   addElementStyles
 ])('div')
-const HeaderTitle = transformPropsWith([
+const HeaderTitle = tx([
   addTitleElementStyles,
   addElementStyles
 ])('h1')

--- a/examples/double-size.js
+++ b/examples/double-size.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 
-import transformPropsWith from 'transform-props-with'
+import tx from 'transform-props-with'
 
 import BaseComponent from './base-component'
 
@@ -14,7 +14,7 @@ const doubleSize = (oldProps) => {
   }
 }
 
-const DecoratedComponent = transformPropsWith(doubleSize)(BaseComponent)
+const DecoratedComponent = tx(doubleSize)(BaseComponent)
 
 ReactDOM.render(
   <DecoratedComponent size={ 100 } />,

--- a/examples/switch-foo-bar.js
+++ b/examples/switch-foo-bar.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 
-import transformPropsWith from 'transform-props-with'
+import tx from 'transform-props-with'
 
 import BaseComponent from './base-component'
 
@@ -15,7 +15,7 @@ const switchFooBar = (oldProps) => {
   }
 }
 
-const DecoratedComponent = transformPropsWith(switchFooBar)(BaseComponent)
+const DecoratedComponent = tx(switchFooBar)(BaseComponent)
 
 ReactDOM.render(
   <DecoratedComponent foo='The Garden Party' bar={ 1963 } />,

--- a/examples/track-click.js
+++ b/examples/track-click.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 
-import transformPropsWith from 'transform-props-with'
+import tx from 'transform-props-with'
 
 import { sendTrackInfo } from './path/to/analytics'
 
@@ -23,7 +23,7 @@ const trackClick = (oldProps) => {
   return props
 }
 
-const DecoratedComponent = transformPropsWith(trackClick)('a')
+const DecoratedComponent = tx(trackClick)('a')
 
 ReactDOM.render(
   <DecoratedComponent

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -8,7 +8,7 @@ var ReactDOM = require('react-dom')
 var TestUtils = require('react-addons-test-utils')
 var wrap = require('react-stateless-wrapper').wrap
 
-var transformPropsWith = require('../').default
+var tx = require('../').default
 
 var BaseComponent = function (props) {
   return React.createElement('div', null, props.size) // eslint-disable-line
@@ -25,7 +25,7 @@ var addFive = function (oldProps) {
 describe('transformPropsWith', function () {
   it('works', function () {
     var DecoratedComponent = wrap(
-      transformPropsWith(doubleSize)(BaseComponent)
+      tx(doubleSize)(BaseComponent)
     )
     var component = TestUtils.renderIntoDocument(
       React.createElement(DecoratedComponent, { size: 10 })
@@ -37,7 +37,7 @@ describe('transformPropsWith', function () {
 
   it('does not modify original component with no transformations', function () {
     var DecoratedComponent = wrap(
-      transformPropsWith()(BaseComponent)
+      tx()(BaseComponent)
     )
     var component = TestUtils.renderIntoDocument(
       React.createElement(DecoratedComponent, { size: 10 })
@@ -49,7 +49,7 @@ describe('transformPropsWith', function () {
 
   it('accepts array of transformations', function () {
     var DecoratedComponent = wrap(
-      transformPropsWith([doubleSize, addFive])(BaseComponent)
+      tx([doubleSize, addFive])(BaseComponent)
     )
     var component = TestUtils.renderIntoDocument(
       React.createElement(DecoratedComponent, { size: 10 })
@@ -61,7 +61,7 @@ describe('transformPropsWith', function () {
 
   it('merges props with object', function () {
     var DecoratedComponent = wrap(
-      transformPropsWith({ size: 30 })(BaseComponent)
+      tx({ size: 30 })(BaseComponent)
     )
     var component = TestUtils.renderIntoDocument(
       React.createElement(DecoratedComponent, { size: 10 })
@@ -73,7 +73,7 @@ describe('transformPropsWith', function () {
 
   it('accepts mixed array of transformations and objects', function () {
     var DecoratedComponent = wrap(
-      transformPropsWith([doubleSize, { size: 10 }])(BaseComponent)
+      tx([doubleSize, { size: 10 }])(BaseComponent)
     )
     var component = TestUtils.renderIntoDocument(
       React.createElement(DecoratedComponent, {})


### PR DESCRIPTION
`transformPropsWith` is sometimes too long; `tx` overcomes this problem.
