### PR TITLE
Reverse array API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## 2.0.0 - 2016-xx-yy
+### Reverse list resolving
+- List of transformations is now resolved left to right
+- Added (this) change log
+
+## 1.1.0 - 2016-04-11
+### Dependencies changes
+- Replace own methods with Lodash
+- List React as a peer dependency
+
+## 1.0.0 - 2016-03-19
+### Initial release
+- First stable release of the package

--- a/README.md
+++ b/README.md
@@ -61,21 +61,21 @@ const setStarsTo10 = (oldProps) => objectAssign({}, oldProps, { stars: 10 })
 #### Multiple transformations
 
 Pass an array of transformations to the function and they will all be combined
-to a single transformation *right to left*.
+to a single transformation *left to right*.
 
 In the following example `addFive` would be applied first and `doubleSize`
 will be called with props returned by it.
 
 ```js
 const DecoratedComponent =
-  tx([doubleSize, addFive])(BaseComponent)
+  tx([ addFive, doubleSize ])(BaseComponent)
 ```
 
 Of course, transformations and object merges can be mixed.
 
 ```js
 const DecoratedComponent =
-  tx([doubleSize, { stars: 10 }, addFive])(BaseComponent)
+  tx([ addFive, { stars: 10 }, doubleSize ])(BaseComponent)
 ```
 
 #### ES7 decorators
@@ -102,5 +102,5 @@ class DecoratedComponent extends BaseComponent {}
 React v0.14.0 ([release notes](https://facebook.github.io/react/blog/2015/10/07/react-v0.14.html)).
 
 * Polyfill for
-[Array.prototype.reduceRight] (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/ReduceRight)
+[Array.prototype.reduce] (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Reduce)
 might be needed to support older browsers.

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ const expandShorthands = (tr) => {
 export default (transformations = []) => {
   const transformsList = castArray(transformations).map(expandShorthands)
 
-  const transform = Array.prototype.reduceRight.bind(
+  const transform = Array.prototype.reduce.bind(
     transformsList,
     (props, tr) => tr(props)
   )

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -49,7 +49,7 @@ describe('transformPropsWith', function () {
 
   it('accepts array of transformations', function () {
     var DecoratedComponent = wrap(
-      tx([doubleSize, addFive])(BaseComponent)
+      tx([ addFive, doubleSize ])(BaseComponent)
     )
     var component = TestUtils.renderIntoDocument(
       React.createElement(DecoratedComponent, { size: 10 })
@@ -73,7 +73,7 @@ describe('transformPropsWith', function () {
 
   it('accepts mixed array of transformations and objects', function () {
     var DecoratedComponent = wrap(
-      tx([doubleSize, { size: 10 }])(BaseComponent)
+      tx([ { size: 10 }, doubleSize ])(BaseComponent)
     )
     var component = TestUtils.renderIntoDocument(
       React.createElement(DecoratedComponent, {})


### PR DESCRIPTION
### This PR changes the order in which transformations are processed.

If `addFive` should be applied first, followed by `doubleSize` it was written this way in v1:

``` js
const DecoratedComponent =
  tx([ doubleSize, addFive ])(BaseComponent)
```

It seemed to confuse people, so from v2 it should be reversed for the same result:

``` js
const DecoratedComponent =
  tx([ addFive, doubleSize ])(BaseComponent)
```

To keep track of changes a change log was introduced.
