### PR TITLE
Add API docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ## 2.0.0 - 2016-xx-yy
 ### Reverse list resolving
 - List of transformations is now resolved left to right
+- Add JSDoc documentation
 - Added (this) change log
 
 ## 1.1.0 - 2016-04-11

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ ReactDOM.render(<DecoratedComponent size={100} />, node);
 // Would render <BaseComponent size={200} />
 ```
 
+See the full [API documentation](docs/api.md) for details.
+
 #### Merge objects
 
 Pass an object to automatically merge it with provided props.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,68 +1,75 @@
+## Modules
+
+* [transform-props-with](#module_transform-props-with)
+    * [~default([transformations])](#module_transform-props-with..default) ⇒ <code>[HigherOrderComponent](#HigherOrderComponent)</code>
+
+## Functions
+
+* [expandShorthands(tr)](#expandShorthands) ⇒ <code>[SimpleTransformation](#SimpleTransformation)</code>
+
+## Typedefs
+
+* [Props](#Props) : <code>object</code>
+* [SimpleTransformation](#SimpleTransformation) ⇒ <code>[Props](#Props)</code>
+* [HigherOrderComponent](#HigherOrderComponent) ⇒ <code>React.Component</code>
+* [Transformation](#Transformation) : <code>[SimpleTransformation](#SimpleTransformation)</code> &#124; <code>object</code>
+
 <a name="module_transform-props-with"></a>
 
 ## transform-props-with
+<a name="module_transform-props-with..default"></a>
 
-* [transform-props-with](#module_transform-props-with)
-    * [module.exports([transformations])](#exp_module_transform-props-with--module.exports) ⇒ <code>HigherOrderComponent</code> ⏏
-        * [~expandShorthands(tr)](#module_transform-props-with--module.exports..expandShorthands) ⇒ <code>SimpleTransformation</code>
-        * [~Props](#module_transform-props-with--module.exports..Props) : <code>object</code>
-        * [~SimpleTransformation](#module_transform-props-with--module.exports..SimpleTransformation) ⇒ <code>Props</code>
-        * [~HigherOrderComponent](#module_transform-props-with--module.exports..HigherOrderComponent) ⇒ <code>React.Component</code>
-        * [~Transformation](#module_transform-props-with--module.exports..Transformation) : <code>SimpleTransformation</code> &#124; <code>object</code>
-
-<a name="exp_module_transform-props-with--module.exports"></a>
-
-### module.exports([transformations]) ⇒ <code>HigherOrderComponent</code> ⏏
+### transform-props-with~default([transformations]) ⇒ <code>[HigherOrderComponent](#HigherOrderComponent)</code>
 Returns the sum of a and b
 
-**Kind**: Exported function
+**Kind**: inner method of <code>[transform-props-with](#module_transform-props-with)</code>
 
 | Param | Type | Default |
 | --- | --- | --- |
-| [transformations] | <code>Transformation</code> &#124; <code>Array.&lt;Transformation&gt;</code> | <code>[]</code> |
+| [transformations] | <code>[Transformation](#Transformation)</code> &#124; <code>[Array.&lt;Transformation&gt;](#Transformation)</code> | <code>[]</code> |
 
-<a name="module_transform-props-with--module.exports..expandShorthands"></a>
+<a name="expandShorthands"></a>
 
-#### module.exports~expandShorthands(tr) ⇒ <code>SimpleTransformation</code>
+## expandShorthands(tr) ⇒ <code>[SimpleTransformation](#SimpleTransformation)</code>
 Returns the sum of a and b
 
-**Kind**: inner method of <code>[module.exports](#exp_module_transform-props-with--module.exports)</code>
+**Kind**: global function
 
 | Param | Type |
 | --- | --- |
-| tr | <code>Transformation</code> |
+| tr | <code>[Transformation](#Transformation)</code> |
 
-<a name="module_transform-props-with--module.exports..Props"></a>
+<a name="Props"></a>
 
-#### module.exports~Props : <code>object</code>
+## Props : <code>object</code>
 A number, or a string containing a number.
 
-**Kind**: inner typedef of <code>[module.exports](#exp_module_transform-props-with--module.exports)</code>
-<a name="module_transform-props-with--module.exports..SimpleTransformation"></a>
+**Kind**: global typedef
+<a name="SimpleTransformation"></a>
 
-#### module.exports~SimpleTransformation ⇒ <code>Props</code>
+## SimpleTransformation ⇒ <code>[Props](#Props)</code>
 This callback is displayed as part of the Requester class.
 
-**Kind**: inner typedef of <code>[module.exports](#exp_module_transform-props-with--module.exports)</code>
+**Kind**: global typedef
 
 | Param | Type |
 | --- | --- |
-| oldProps | <code>Props</code> |
+| oldProps | <code>[Props](#Props)</code> |
 
-<a name="module_transform-props-with--module.exports..HigherOrderComponent"></a>
+<a name="HigherOrderComponent"></a>
 
-#### module.exports~HigherOrderComponent ⇒ <code>React.Component</code>
+## HigherOrderComponent ⇒ <code>React.Component</code>
 Higher-order React Component.
 
-**Kind**: inner typedef of <code>[module.exports](#exp_module_transform-props-with--module.exports)</code>
+**Kind**: global typedef
 
 | Param | Type |
 | --- | --- |
 | BaseComponent | <code>React.Component</code> |
 
-<a name="module_transform-props-with--module.exports..Transformation"></a>
+<a name="Transformation"></a>
 
-#### module.exports~Transformation : <code>SimpleTransformation</code> &#124; <code>object</code>
+## Transformation : <code>[SimpleTransformation](#SimpleTransformation)</code> &#124; <code>object</code>
 A number, or a string containing a number.
 
-**Kind**: inner typedef of <code>[module.exports](#exp_module_transform-props-with--module.exports)</code>
+**Kind**: global typedef

--- a/docs/api.md
+++ b/docs/api.md
@@ -3,10 +3,6 @@
 * [transform-props-with](#module_transform-props-with)
     * [~default([transformations])](#module_transform-props-with..default) ⇒ <code>[HigherOrderComponent](#HigherOrderComponent)</code>
 
-## Functions
-
-* [expandShorthands(tr)](#expandShorthands) ⇒ <code>[SimpleTransformation](#SimpleTransformation)</code>
-
 ## Typedefs
 
 * [Props](#Props) : <code>object</code>
@@ -20,56 +16,50 @@
 <a name="module_transform-props-with..default"></a>
 
 ### transform-props-with~default([transformations]) ⇒ <code>[HigherOrderComponent](#HigherOrderComponent)</code>
-Returns the sum of a and b
+Higher-order component generator.
+Will change props with passed transformaton(s).
+Array of transformatons is evaluated left to right.
 
-**Kind**: inner method of <code>[transform-props-with](#module_transform-props-with)</code>
+**Kind**: inner method of <code>[transform-props-with](#module_transform-props-with)</code>  
 
 | Param | Type | Default |
 | --- | --- | --- |
-| [transformations] | <code>[Transformation](#Transformation)</code> &#124; <code>[Array.&lt;Transformation&gt;](#Transformation)</code> | <code>[]</code> |
-
-<a name="expandShorthands"></a>
-
-## expandShorthands(tr) ⇒ <code>[SimpleTransformation](#SimpleTransformation)</code>
-Returns the sum of a and b
-
-**Kind**: global function
-
-| Param | Type |
-| --- | --- |
-| tr | <code>[Transformation](#Transformation)</code> |
+| [transformations] | <code>[Transformation](#Transformation)</code> &#124; <code>[Array.&lt;Transformation&gt;](#Transformation)</code> | <code>[]</code> | 
 
 <a name="Props"></a>
 
 ## Props : <code>object</code>
-A number, or a string containing a number.
+A plain object. Should not be mutated.
 
-**Kind**: global typedef
+**Kind**: global typedef  
 <a name="SimpleTransformation"></a>
 
 ## SimpleTransformation ⇒ <code>[Props](#Props)</code>
-This callback is displayed as part of the Requester class.
+Middleware function for changing props.
+A function which takes Props as input and returns new Props.
 
-**Kind**: global typedef
+**Kind**: global typedef  
 
 | Param | Type |
 | --- | --- |
-| oldProps | <code>[Props](#Props)</code> |
+| oldProps | <code>[Props](#Props)</code> | 
 
 <a name="HigherOrderComponent"></a>
 
 ## HigherOrderComponent ⇒ <code>React.Component</code>
 Higher-order React Component.
+A function that enhances passed component.
 
-**Kind**: global typedef
+**Kind**: global typedef  
 
 | Param | Type |
 | --- | --- |
-| BaseComponent | <code>React.Component</code> |
+| BaseComponent | <code>React.Component</code> | 
 
 <a name="Transformation"></a>
 
 ## Transformation : <code>[SimpleTransformation](#SimpleTransformation)</code> &#124; <code>object</code>
-A number, or a string containing a number.
+When a plane object is passed it will be used to
+extend props (with override).
 
-**Kind**: global typedef
+**Kind**: global typedef  

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,68 @@
+<a name="module_transform-props-with"></a>
+
+## transform-props-with
+
+* [transform-props-with](#module_transform-props-with)
+    * [module.exports([transformations])](#exp_module_transform-props-with--module.exports) ⇒ <code>HigherOrderComponent</code> ⏏
+        * [~expandShorthands(tr)](#module_transform-props-with--module.exports..expandShorthands) ⇒ <code>SimpleTransformation</code>
+        * [~Props](#module_transform-props-with--module.exports..Props) : <code>object</code>
+        * [~SimpleTransformation](#module_transform-props-with--module.exports..SimpleTransformation) ⇒ <code>Props</code>
+        * [~HigherOrderComponent](#module_transform-props-with--module.exports..HigherOrderComponent) ⇒ <code>React.Component</code>
+        * [~Transformation](#module_transform-props-with--module.exports..Transformation) : <code>SimpleTransformation</code> &#124; <code>object</code>
+
+<a name="exp_module_transform-props-with--module.exports"></a>
+
+### module.exports([transformations]) ⇒ <code>HigherOrderComponent</code> ⏏
+Returns the sum of a and b
+
+**Kind**: Exported function
+
+| Param | Type | Default |
+| --- | --- | --- |
+| [transformations] | <code>Transformation</code> &#124; <code>Array.&lt;Transformation&gt;</code> | <code>[]</code> |
+
+<a name="module_transform-props-with--module.exports..expandShorthands"></a>
+
+#### module.exports~expandShorthands(tr) ⇒ <code>SimpleTransformation</code>
+Returns the sum of a and b
+
+**Kind**: inner method of <code>[module.exports](#exp_module_transform-props-with--module.exports)</code>
+
+| Param | Type |
+| --- | --- |
+| tr | <code>Transformation</code> |
+
+<a name="module_transform-props-with--module.exports..Props"></a>
+
+#### module.exports~Props : <code>object</code>
+A number, or a string containing a number.
+
+**Kind**: inner typedef of <code>[module.exports](#exp_module_transform-props-with--module.exports)</code>
+<a name="module_transform-props-with--module.exports..SimpleTransformation"></a>
+
+#### module.exports~SimpleTransformation ⇒ <code>Props</code>
+This callback is displayed as part of the Requester class.
+
+**Kind**: inner typedef of <code>[module.exports](#exp_module_transform-props-with--module.exports)</code>
+
+| Param | Type |
+| --- | --- |
+| oldProps | <code>Props</code> |
+
+<a name="module_transform-props-with--module.exports..HigherOrderComponent"></a>
+
+#### module.exports~HigherOrderComponent ⇒ <code>React.Component</code>
+Higher-order React Component.
+
+**Kind**: inner typedef of <code>[module.exports](#exp_module_transform-props-with--module.exports)</code>
+
+| Param | Type |
+| --- | --- |
+| BaseComponent | <code>React.Component</code> |
+
+<a name="module_transform-props-with--module.exports..Transformation"></a>
+
+#### module.exports~Transformation : <code>SimpleTransformation</code> &#124; <code>object</code>
+A number, or a string containing a number.
+
+**Kind**: inner typedef of <code>[module.exports](#exp_module_transform-props-with--module.exports)</code>

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "./lib/index.js",
   "scripts": {
     "compile": "babel src --out-dir lib",
+    "docs": "jsdoc2md --module-index-format grouped --global-index-format grouped src/*.js > docs/api.md",
     "prepublish": "npm run compile",
     "pretest": "npm run compile",
     "test": "standard && jest"
@@ -29,7 +30,8 @@
     "babel-cli": "^6.8.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.3.13",
-    "jest-cli": "^12.0.2",
+    "jest-cli": "^11.0.0",
+    "jsdoc-to-markdown": "^1.3.4",
     "react": "^15.0.2",
     "react-addons-test-utils": "^15.0.1",
     "react-dom": "^15.0.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "babel-cli": "^6.8.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.3.13",
-    "jest-cli": "^11.0.0",
+    "jest-cli": "^12.0.2",
     "jsdoc-to-markdown": "^1.3.4",
     "react": "^15.0.2",
     "react-addons-test-utils": "^15.0.1",

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import isPlainObject from 'lodash/isPlainObject'
 /**
  * A number, or a string containing a number.
  * @typedef {object} Props
+ * @global
  */
 
 /**
@@ -15,6 +16,7 @@ import isPlainObject from 'lodash/isPlainObject'
  * @callback SimpleTransformation
  * @param {Props} oldProps
  * @return {Props}
+ * @global
  */
 
 /**
@@ -22,17 +24,20 @@ import isPlainObject from 'lodash/isPlainObject'
  * @callback HigherOrderComponent
  * @param {React.Component} BaseComponent
  * @return {React.Component}
+ * @global
  */
 
 /**
  * A number, or a string containing a number.
  * @typedef {(SimpleTransformation|object)} Transformation
+ * @global
  */
 
 /**
  * Returns the sum of a and b
  * @param {Transformation} tr
  * @returns {SimpleTransformation}
+ * @alias expandShorthands
  */
 const expandShorthands = (tr) => {
   if (typeof tr === 'function') {
@@ -48,7 +53,7 @@ const expandShorthands = (tr) => {
 
 /**
  * Returns the sum of a and b
- * @function
+ * @function default
  * @param {Transformation|Transformation[]} [transformations = []]
  * @returns {HigherOrderComponent}
  */

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,39 @@
+/** @module transform-props-with */
+
 import React from 'react'
 import objectAssign from 'object-assign'
 import castArray from 'lodash/castArray'
 import isPlainObject from 'lodash/isPlainObject'
 
+/**
+ * A number, or a string containing a number.
+ * @typedef {object} Props
+ */
+
+/**
+ * This callback is displayed as part of the Requester class.
+ * @callback SimpleTransformation
+ * @param {Props} oldProps
+ * @return {Props}
+ */
+
+/**
+ * Higher-order React Component.
+ * @callback HigherOrderComponent
+ * @param {React.Component} BaseComponent
+ * @return {React.Component}
+ */
+
+/**
+ * A number, or a string containing a number.
+ * @typedef {(SimpleTransformation|object)} Transformation
+ */
+
+/**
+ * Returns the sum of a and b
+ * @param {Transformation} tr
+ * @returns {SimpleTransformation}
+ */
 const expandShorthands = (tr) => {
   if (typeof tr === 'function') {
     return tr
@@ -15,6 +46,12 @@ const expandShorthands = (tr) => {
   throw new Error('Transformation must be a function or a plain object.')
 }
 
+/**
+ * Returns the sum of a and b
+ * @function
+ * @param {Transformation|Transformation[]} [transformations = []]
+ * @returns {HigherOrderComponent}
+ */
 export default (transformations = []) => {
   const transformsList = castArray(transformations).map(expandShorthands)
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,13 +6,14 @@ import castArray from 'lodash/castArray'
 import isPlainObject from 'lodash/isPlainObject'
 
 /**
- * A number, or a string containing a number.
+ * A plain object. Should not be mutated.
  * @typedef {object} Props
  * @global
  */
 
 /**
- * This callback is displayed as part of the Requester class.
+ * Middleware function for changing props.
+ * A function which takes Props as input and returns new Props.
  * @callback SimpleTransformation
  * @param {Props} oldProps
  * @return {Props}
@@ -21,6 +22,7 @@ import isPlainObject from 'lodash/isPlainObject'
 
 /**
  * Higher-order React Component.
+ * A function that enhances passed component.
  * @callback HigherOrderComponent
  * @param {React.Component} BaseComponent
  * @return {React.Component}
@@ -28,7 +30,8 @@ import isPlainObject from 'lodash/isPlainObject'
  */
 
 /**
- * A number, or a string containing a number.
+ * When a plane object is passed it will be used to
+ * extend props (with override).
  * @typedef {(SimpleTransformation|object)} Transformation
  * @global
  */
@@ -38,6 +41,7 @@ import isPlainObject from 'lodash/isPlainObject'
  * @param {Transformation} tr
  * @returns {SimpleTransformation}
  * @alias expandShorthands
+ * @private
  */
 const expandShorthands = (tr) => {
   if (typeof tr === 'function') {
@@ -52,7 +56,9 @@ const expandShorthands = (tr) => {
 }
 
 /**
- * Returns the sum of a and b
+ * Higher-order component generator.
+ * Will change props with passed transformaton(s).
+ * Array of transformatons is evaluated left to right.
  * @function default
  * @param {Transformation|Transformation[]} [transformations = []]
  * @returns {HigherOrderComponent}


### PR DESCRIPTION
Adding JSDoc documentation makes it easier for developers to use and extend this library.

The annotations are then processed into a easily-readable markdown file.
